### PR TITLE
just add 'read' and 'writeonly' on bool props

### DIFF
--- a/tornado_swirl/docparser.py
+++ b/tornado_swirl/docparser.py
@@ -58,7 +58,7 @@ class Boolean(object):
 
 _PROPS_TYPE_LOOKUP = {
     Boolean: ('exclusiveMinimum', 'exclusiveMaximum', 'uniqueItems',
-              'allowEmptyValue', 'deprecated'),
+              'allowEmptyValue', 'deprecated', 'readOnly', 'writeOnly'),
     Number: ('minimum', 'maximum', 'multipleOf', 'minItems',
              'maxItems', 'maxLength', 'minLength', 'uniqueItems',
              'minProperties', 'maxProperties')


### PR DESCRIPTION
When we use the properties 'readonly' and 'writeonly', the value is like 'string' in json.

this pr puts these properties with the real boolean value