### PR TITLE
http 204 - no body content

### DIFF
--- a/tornado_swirl/docparser.py
+++ b/tornado_swirl/docparser.py
@@ -58,7 +58,7 @@ class Boolean(object):
 
 _PROPS_TYPE_LOOKUP = {
     Boolean: ('exclusiveMinimum', 'exclusiveMaximum', 'uniqueItems',
-              'allowEmptyValue', 'deprecated'),
+              'allowEmptyValue', 'deprecated', 'readOnly', 'writeOnly'),
     Number: ('minimum', 'maximum', 'multipleOf', 'minItems',
              'maxItems', 'maxLength', 'minLength', 'uniqueItems',
              'minProperties', 'maxProperties')

--- a/tornado_swirl/views.py
+++ b/tornado_swirl/views.py
@@ -318,10 +318,11 @@ class SwaggerApiHandler(tornado.web.RequestHandler):
             if param:
                 params[param.name] = {
                     "description": param.description,
-                    "content":
-                        # should return default produces if none, otherwise detect from type
-                        self._detect_content(param)
                 }
+                # should return default produces if none, otherwise detect from type
+                content = self._detect_content(param)
+                if content:
+                    params[param.name]['content'] = content
                 # TODO: implement examples
         return params
 


### PR DESCRIPTION
As described in the [swagger doc](https://swagger.io/docs/specification/describing-responses/), the 'content' property should not exist when responses have no body.

This commit removes this property for these cases.

If you are using [ReDoc](https://github.com/Redocly/redoc), this will also solve the problem.

