### PR TITLE
set default value for bearerformat

### DIFF
--- a/tornado_swirl/openapi/security.py
+++ b/tornado_swirl/openapi/security.py
@@ -28,8 +28,7 @@ class HTTP(SecurityScheme):
     
     def __init__(self, scheme, bearerFormat=None):
         self.scheme = scheme
-        if str(scheme).lower() == 'bearer':
-            self.bearerFormat = bearerFormat
+        self.bearerFormat = bearerFormat
 
     @property
     def type(self):


### PR DESCRIPTION
Set bearer format value since the previous version could be generate an error when not used bearer as name schema